### PR TITLE
add PostgreSQL integration for internal commands

### DIFF
--- a/src/Bw.Cqrs.InternalCommands.Postgres/Data/CommandDbContext.cs
+++ b/src/Bw.Cqrs.InternalCommands.Postgres/Data/CommandDbContext.cs
@@ -1,0 +1,26 @@
+using Bw.Cqrs.InternalCommands.Postgres.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bw.Cqrs.InternalCommands.Postgres.Data;
+
+public class CommandDbContext : DbContext
+{
+    public DbSet<CommandEntity> InternalCommands { get; set; } = null!;
+
+    public CommandDbContext(DbContextOptions<CommandDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<CommandEntity>(entity =>
+        {
+            entity.ToTable("internal_commands");
+            
+            entity.HasIndex(e => e.Status);
+            entity.HasIndex(e => e.ScheduledOn);
+            entity.HasIndex(e => e.ProcessedOn);
+        });
+    }
+} 

--- a/src/Bw.Cqrs.InternalCommands.Postgres/Models/CommandEntity.cs
+++ b/src/Bw.Cqrs.InternalCommands.Postgres/Models/CommandEntity.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using Bw.Cqrs.Commands.Enums;
+
+namespace Bw.Cqrs.InternalCommands.Postgres.Models;
+
+public class CommandEntity
+{
+    [Key]
+    public Guid Id { get; set; }
+    
+    [Required]
+    [MaxLength(500)]
+    public string Type { get; set; } = string.Empty;
+    
+    [Required]
+    public string Data { get; set; } = string.Empty;
+    
+    [Required]
+    public DateTime ScheduledOn { get; set; }
+    
+    public DateTime? ProcessedOn { get; set; }
+    
+    public int RetryCount { get; set; }
+    
+    [MaxLength(2000)]
+    public string? Error { get; set; }
+    
+    [Required]
+    public InternalCommandStatus Status { get; set; }
+    
+    public DateTime CreatedAt { get; set; }
+    
+    public DateTime? LastRetryAt { get; set; }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Bw.Cqrs.InternalCommands.Postgres.Tests.csproj
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Bw.Cqrs.InternalCommands.Postgres.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Bw.Cqrs.InternalCommands.Postgres.Tests</RootNamespace>
+    <AssemblyName>Bw.Cqrs.InternalCommands.Postgres.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Testcontainers" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bw.Cqrs.InternalCommands.Postgres\Bw.Cqrs.InternalCommands.Postgres.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Data/PostgresInternalCommandDbContextTests.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Data/PostgresInternalCommandDbContextTests.cs
@@ -1,0 +1,72 @@
+using Bw.Cqrs.Commands.Enums;
+using Bw.Cqrs.Commands.Postgres.Tests.Integration;
+using Bw.Cqrs.InternalCommands.Postgres.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Data;
+
+public class CommandDbContextTests : PostgresIntegrationTestBase
+{
+    [Fact]
+    public async Task OnModelCreating_ShouldConfigureEntityCorrectly()
+    {
+        // Arrange
+        var command = new CommandEntity
+        {
+            Type = "TestCommand",
+            Data = "test data",
+            Status = InternalCommandStatus.Scheduled,
+            ScheduledOn = DateTime.UtcNow
+        };
+
+        // Act
+        DbContext.InternalCommands.Add(command);
+        await DbContext.SaveChangesAsync();
+
+        // Assert
+        var savedCommand = await DbContext.InternalCommands.FirstAsync();
+        Assert.Equal("TestCommand", savedCommand.Type);
+        Assert.Equal("test data", savedCommand.Data);
+        Assert.Equal(InternalCommandStatus.Scheduled, savedCommand.Status);
+        Assert.NotEqual(default, savedCommand.ScheduledOn);
+    }
+
+    [Fact]
+    public async Task OnModelCreating_ShouldEnforceRequiredFields()
+    {
+        // Arrange
+        var command = new CommandEntity
+        {
+            Status = InternalCommandStatus.Scheduled,
+            ScheduledOn = DateTime.UtcNow
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DbUpdateException>(async () =>
+        {
+            DbContext.InternalCommands.Add(command);
+            await DbContext.SaveChangesAsync();
+        });
+    }
+
+    [Fact]
+    public async Task OnModelCreating_ShouldEnforceMaxLength()
+    {
+        // Arrange
+        var command = new CommandEntity
+        {
+            Type = new string('x', 256),
+            Data = "test data",
+            Status = InternalCommandStatus.Scheduled,
+            ScheduledOn = DateTime.UtcNow
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DbUpdateException>(async () =>
+        {
+            DbContext.InternalCommands.Add(command);
+            await DbContext.SaveChangesAsync();
+        });
+    }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Extensions/PostgresStorageExtensionsTests.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Extensions/PostgresStorageExtensionsTests.cs
@@ -1,0 +1,52 @@
+using Bw.Cqrs.Commands.Configuration;
+using Bw.Cqrs.Commands.Contracts;
+using Bw.Cqrs.InternalCommands.Postgres.Extensions;
+using Bw.Cqrs.InternalCommands.Postgres.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Bw.Cqrs.Configuration;
+using System.Reflection;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Extensions;
+
+public class PostgresStorageExtensionsTests
+{
+    [Fact]
+    public void UsePostgres_ShouldRegisterRequiredServices()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var cqrsBuilder = new CqrsBuilder(services, new[] { Assembly.GetExecutingAssembly() });
+        var builder = new InternalCommandStorageBuilder(services, cqrsBuilder);
+
+        // Act
+        builder.UsePostgres(options =>
+        {
+            options.ConnectionString = "Host=localhost;Database=test;Username=test;Password=test";
+            options.CommandTimeout = TimeSpan.FromSeconds(30);
+        });
+
+        // Assert
+        var serviceProvider = services.BuildServiceProvider();
+        var store = serviceProvider.GetService<IInternalCommandStore>();
+        Assert.NotNull(store);
+        Assert.IsType<PostgresInternalCommandStore>(store);
+    }
+
+    [Fact]
+    public void UsePostgres_WithInvalidOptions_ShouldThrow()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var cqrsBuilder = new CqrsBuilder(services, new[] { Assembly.GetExecutingAssembly() });
+        var builder = new InternalCommandStorageBuilder(services, cqrsBuilder);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.UsePostgres(options =>
+            {
+                options.ConnectionString = string.Empty;
+                options.CommandTimeout = TimeSpan.FromSeconds(0);
+            }));
+    }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Integration/PostgresIntegrationTestBase.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Integration/PostgresIntegrationTestBase.cs
@@ -1,0 +1,40 @@
+using Bw.Cqrs.InternalCommands.Postgres.Data;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Integration;
+
+public abstract class PostgresIntegrationTestBase : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container;
+    protected readonly CommandDbContext DbContext;
+
+    protected PostgresIntegrationTestBase()
+    {
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:16")
+            .WithDatabase("cqrs_test")
+            .WithUsername("test")
+            .WithPassword("test")
+            .Build();
+
+        var options = new DbContextOptionsBuilder<CommandDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .Options;
+
+        DbContext = new CommandDbContext(options);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        await DbContext.Database.EnsureCreatedAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await DbContext.Database.EnsureDeletedAsync();
+        await _container.DisposeAsync();
+    }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Integration/PostgresInternalCommandStoreTests.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Integration/PostgresInternalCommandStoreTests.cs
@@ -1,0 +1,112 @@
+using Bw.Cqrs.Commands.Base;
+using Bw.Cqrs.Commands.Enums;
+using Bw.Cqrs.InternalCommands.Postgres.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Integration;
+
+public class PostgresInternalCommandStoreTests : PostgresIntegrationTestBase
+{
+    private readonly PostgresInternalCommandStore _store;
+    private readonly Mock<ILogger<PostgresInternalCommandStore>> _loggerMock;
+
+    public PostgresInternalCommandStoreTests()
+    {
+        _loggerMock = new Mock<ILogger<PostgresInternalCommandStore>>();
+        _store = new PostgresInternalCommandStore(DbContext, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldSaveCommand()
+    {
+        // Arrange
+        var command = new TestCommand { Data = "test" };
+
+        // Act
+        await _store.SaveAsync(command);
+
+        // Assert
+        var savedCommand = await DbContext.InternalCommands.FirstAsync();
+        Assert.Equal(command.GetType().AssemblyQualifiedName, savedCommand.Type);
+        Assert.Equal(command.Data, savedCommand.Data);
+        Assert.Equal(InternalCommandStatus.Scheduled, savedCommand.Status);
+    }
+
+    [Fact]
+    public async Task GetCommandsToExecuteAsync_ShouldReturnScheduledCommands()
+    {
+        // Arrange
+        var command1 = new TestCommand { Data = "test1" };
+        var command2 = new TestCommand { Data = "test2" };
+        await _store.SaveAsync(command1);
+        await _store.SaveAsync(command2);
+
+        // Act
+        var commands = await _store.GetCommandsToExecuteAsync();
+
+        // Assert
+        Assert.Equal(2, commands.Count());
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_ShouldUpdateCommandStatus()
+    {
+        // Arrange
+        var command = new TestCommand { Data = "test" };
+        await _store.SaveAsync(command);
+
+        // Act
+        await _store.UpdateStatusAsync(command.Id, InternalCommandStatus.Processing);
+
+        // Assert
+        var updatedCommand = await DbContext.InternalCommands.FirstAsync();
+        Assert.Equal(InternalCommandStatus.Processing, updatedCommand.Status);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_ShouldDeleteOldCommands()
+    {
+        // Arrange
+        var command = new TestCommand { Data = "test" };
+        await _store.SaveAsync(command);
+        await _store.UpdateStatusAsync(command.Id, InternalCommandStatus.Processed);
+
+        // Act
+        await _store.CleanupAsync(DateTime.UtcNow.AddDays(1));
+
+        // Assert
+        var commands = await DbContext.InternalCommands.ToListAsync();
+        Assert.Empty(commands);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ShouldReturnCorrectStats()
+    {
+        // Arrange
+        var command1 = new TestCommand { Data = "test1" };
+        var command2 = new TestCommand { Data = "test2" };
+        await _store.SaveAsync(command1);
+        await _store.SaveAsync(command2);
+        await _store.UpdateStatusAsync(command1.Id, InternalCommandStatus.Processed);
+
+        // Act
+        var stats = await _store.GetStatsAsync();
+
+        // Assert
+        Assert.Equal(2, stats.TotalCommands);
+        Assert.Equal(1, stats.ScheduledCommands);
+        Assert.Equal(1, stats.ProcessedCommands);
+    }
+
+    private class TestCommand : InternalCommand
+    {
+        public string Data { get; set; } = string.Empty;
+
+        public TestCommand() : base()
+        {
+        }
+    }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Models/PostgresInternalCommandTests.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Models/PostgresInternalCommandTests.cs
@@ -1,0 +1,60 @@
+using Bw.Cqrs.Commands.Enums;
+using Bw.Cqrs.InternalCommands.Postgres.Models;
+using Xunit;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Models;
+
+public class CommandEntityTests
+{
+    [Fact]
+    public void Constructor_ShouldInitializeProperties()
+    {
+        // Act
+        var command = new CommandEntity();
+
+        // Assert
+        Assert.Equal(Guid.Empty, command.Id);
+        Assert.Null(command.Type);
+        Assert.Null(command.Data);
+        Assert.Equal(default, command.ScheduledOn);
+        Assert.Equal(default, command.ProcessedOn);
+        Assert.Equal(0, command.RetryCount);
+        Assert.Null(command.Error);
+        Assert.Equal(InternalCommandStatus.Scheduled, command.Status);
+        Assert.Equal(DateTime.UtcNow.Date, command.CreatedAt.Date);
+        Assert.Equal(default, command.LastRetryAt);
+    }
+
+    [Fact]
+    public void ToString_ShouldReturnTypeAndId()
+    {
+        // Arrange
+        var command = new CommandEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = "TestCommand"
+        };
+
+        // Act
+        var result = command.ToString();
+
+        // Assert
+        Assert.Equal($"TestCommand ({command.Id})", result);
+    }
+
+    [Fact]
+    public void ToString_WithNullType_ShouldReturnIdOnly()
+    {
+        // Arrange
+        var command = new CommandEntity
+        {
+            Id = Guid.NewGuid()
+        };
+
+        // Act
+        var result = command.ToString();
+
+        // Assert
+        Assert.Equal(command.Id.ToString(), result);
+    }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Options/PostgresOptionsTests.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Options/PostgresOptionsTests.cs
@@ -1,0 +1,50 @@
+using Bw.Cqrs.InternalCommands.Postgres.Models;
+using Xunit;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Options;
+
+public class PostgresOptionsTests
+{
+    [Fact]
+    public void Validate_WithValidOptions_ShouldNotThrow()
+    {
+        // Arrange
+        var options = new PostgresOptions
+        {
+            ConnectionString = "Host=localhost;Database=test;Username=test;Password=test",
+            CommandTimeout = TimeSpan.FromSeconds(30)
+        };
+
+        // Act & Assert
+        var exception = Record.Exception(() => options.Validate());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_WithInvalidConnectionString_ShouldThrow()
+    {
+        // Arrange
+        var options = new PostgresOptions
+        {
+            ConnectionString = string.Empty,
+            CommandTimeout = TimeSpan.FromSeconds(30)
+        };
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithInvalidCommandTimeout_ShouldThrow()
+    {
+        // Arrange
+        var options = new PostgresOptions
+        {
+            ConnectionString = "Host=localhost;Database=test;Username=test;Password=test",
+            CommandTimeout = TimeSpan.Zero
+        };
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => options.Validate());
+    }
+} 

--- a/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Services/PostgresInternalCommandStoreTests.cs
+++ b/tests/Bw.Cqrs.InternalCommands.Postgres.Tests/Services/PostgresInternalCommandStoreTests.cs
@@ -1,0 +1,159 @@
+using Bw.Cqrs.Commands.Base;
+using Bw.Cqrs.Commands.Enums;
+using Bw.Cqrs.InternalCommands.Postgres.Services;
+using Bw.Cqrs.InternalCommands.Postgres.Data;
+using Bw.Cqrs.InternalCommands.Postgres.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Bw.Cqrs.Commands.Postgres.Tests.Services;
+
+public class PostgresInternalCommandStoreTests
+{
+    private readonly Mock<CommandDbContext> _dbContextMock;
+    private readonly Mock<ILogger<PostgresInternalCommandStore>> _loggerMock;
+    private readonly PostgresInternalCommandStore _store;
+
+    public PostgresInternalCommandStoreTests()
+    {
+        _dbContextMock = new Mock<CommandDbContext>(new DbContextOptions<CommandDbContext>());
+        _loggerMock = new Mock<ILogger<PostgresInternalCommandStore>>();
+        _store = new PostgresInternalCommandStore(_dbContextMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldSaveCommand()
+    {
+        // Arrange
+        var command = new TestCommand { Data = "test" };
+        var dbSetMock = new Mock<DbSet<CommandEntity>>();
+        _dbContextMock.Setup(x => x.InternalCommands).Returns(dbSetMock.Object);
+
+        // Act
+        await _store.SaveAsync(command);
+
+        // Assert
+        dbSetMock.Verify(x => x.AddAsync(
+            It.Is<CommandEntity>(e => 
+                e.Id == command.Id &&
+                e.Type == command.GetType().AssemblyQualifiedName &&
+                e.Data.Contains("test") &&
+                e.Status == InternalCommandStatus.Scheduled),
+            It.IsAny<CancellationToken>()), 
+            Times.Once);
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCommandsToExecuteAsync_ShouldReturnScheduledCommands()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var commands = new List<CommandEntity>
+        {
+            new() { Id = Guid.NewGuid(), Status = InternalCommandStatus.Scheduled, ScheduledOn = now.AddMinutes(-1) },
+            new() { Id = Guid.NewGuid(), Status = InternalCommandStatus.Processing, ScheduledOn = now.AddMinutes(-1) },
+            new() { Id = Guid.NewGuid(), Status = InternalCommandStatus.Scheduled, ScheduledOn = now.AddMinutes(1) }
+        };
+
+        var dbSetMock = new Mock<DbSet<CommandEntity>>();
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.Provider).Returns(commands.AsQueryable().Provider);
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.Expression).Returns(commands.AsQueryable().Expression);
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.ElementType).Returns(commands.AsQueryable().ElementType);
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.GetEnumerator()).Returns(commands.AsQueryable().GetEnumerator());
+
+        _dbContextMock.Setup(x => x.InternalCommands).Returns(dbSetMock.Object);
+
+        // Act
+        var result = await _store.GetCommandsToExecuteAsync();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(InternalCommandStatus.Scheduled, result.First().Status);
+        Assert.True(result.First().ScheduledOn <= now);
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_ShouldUpdateCommandStatus()
+    {
+        // Arrange
+        var commandId = Guid.NewGuid();
+        var command = new CommandEntity { Id = commandId, Status = InternalCommandStatus.Scheduled };
+        var dbSetMock = new Mock<DbSet<CommandEntity>>();
+        dbSetMock.Setup(x => x.FindAsync(new object[] { commandId }, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(command);
+
+        _dbContextMock.Setup(x => x.InternalCommands).Returns(dbSetMock.Object);
+
+        // Act
+        await _store.UpdateStatusAsync(commandId, InternalCommandStatus.Processing);
+
+        // Assert
+        Assert.Equal(InternalCommandStatus.Processing, command.Status);
+        Assert.NotNull(command.LastRetryAt);
+        Assert.Equal(1, command.RetryCount);
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_ShouldDeleteOldCommands()
+    {
+        // Arrange
+        var cutoffDate = DateTime.UtcNow.AddDays(-1);
+        var dbSetMock = new Mock<DbSet<CommandEntity>>();
+        _dbContextMock.Setup(x => x.InternalCommands).Returns(dbSetMock.Object);
+
+        // Act
+        await _store.CleanupAsync(cutoffDate);
+
+        // Assert
+        dbSetMock.Verify(x => x.RemoveRange(
+            It.Is<IEnumerable<CommandEntity>>(e => e.All(c => c.ProcessedOn < cutoffDate))),
+            Times.Once);
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ShouldReturnCorrectStats()
+    {
+        // Arrange
+        var commands = new List<CommandEntity>
+        {
+            new() { Status = InternalCommandStatus.Scheduled },
+            new() { Status = InternalCommandStatus.Processing },
+            new() { Status = InternalCommandStatus.Processed },
+            new() { Status = InternalCommandStatus.Failed },
+            new() { Status = InternalCommandStatus.Cancelled }
+        };
+
+        var dbSetMock = new Mock<DbSet<CommandEntity>>();
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.Provider).Returns(commands.AsQueryable().Provider);
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.Expression).Returns(commands.AsQueryable().Expression);
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.ElementType).Returns(commands.AsQueryable().ElementType);
+        dbSetMock.As<IQueryable<CommandEntity>>().Setup(x => x.GetEnumerator()).Returns(commands.AsQueryable().GetEnumerator());
+
+        _dbContextMock.Setup(x => x.InternalCommands).Returns(dbSetMock.Object);
+
+        // Act
+        var stats = await _store.GetStatsAsync();
+
+        // Assert
+        Assert.Equal(5, stats.TotalCommands);
+        Assert.Equal(1, stats.ScheduledCommands);
+        Assert.Equal(1, stats.ProcessingCommands);
+        Assert.Equal(1, stats.ProcessedCommands);
+        Assert.Equal(1, stats.FailedCommands);
+        Assert.Equal(1, stats.CancelledCommands);
+    }
+
+    private class TestCommand : InternalCommand
+    {
+        public string Data { get; set; } = string.Empty;
+
+        public TestCommand() : base()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Added PostgreSQL support for internal command storage
- Implemented `CommandEntity` and `CommandDbContext` models
- Added unit and integration tests
- Updated documentation in README.md

## Technical Details
- Using Entity Framework Core for database access
- Implementing Outbox Pattern for command processing
- Added retry mechanism and error handling
- Integration tests using Testcontainers

## Tests
- Unit tests for models and services
- Integration tests for command storage and processing
- Tests for configuration and extensions

## Documentation
- Installation and configuration guide
- Usage examples
- Implementation best practices

## Breaking Changes
None. This is a new feature that adds PostgreSQL support as an optional storage provider.

## Dependencies
- EntityFrameworkCore
- Npgsql.EntityFrameworkCore.PostgreSQL
- Testcontainers.PostgreSql (for tests)