### PR TITLE
Refactor: Rename ICommandBus to ICommandProcessor, IEventBus to IEven… And Fixed Bug for InternalCommand Processing 

### DIFF
--- a/src/Bw.Cqrs.InternalCommands.Postgres/Bw.Cqrs.InternalCommands.Postgres.csproj
+++ b/src/Bw.Cqrs.InternalCommands.Postgres/Bw.Cqrs.InternalCommands.Postgres.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/Bw.Cqrs/Bw.Cqrs.csproj
+++ b/src/Bw.Cqrs/Bw.Cqrs.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Scrutor" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bw.Cqrs/Commands/Base/CommandBase.cs
+++ b/src/Bw.Cqrs/Commands/Base/CommandBase.cs
@@ -1,4 +1,5 @@
 using Bw.Cqrs.Commands.Contracts;
+using Newtonsoft.Json;
 
 namespace Bw.Cqrs.Commands.Base;
 
@@ -10,19 +11,33 @@ public abstract class CommandBase : ICommand
     /// <summary>
     /// Gets the unique identifier for the command
     /// </summary>
+    [JsonProperty]
     public Guid Id { get; private set; }
 
     /// <summary>
     /// Gets the timestamp when the command was created
     /// </summary>
+    [JsonProperty]
     public DateTime Timestamp { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the command
     /// </summary>
-    protected CommandBase()
+    public CommandBase()
     {
         Id = Guid.NewGuid();
         Timestamp = DateTime.UtcNow;
     }
-} 
+
+    /// <summary>
+    /// Initializes a new instance of the command
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="timestamp"></param>
+    [JsonConstructor]
+    public CommandBase(Guid id, DateTime timestamp)
+    {
+        Id = id;
+        Timestamp = timestamp;
+    }
+}

--- a/src/Bw.Cqrs/Commands/Base/InternalCommand.cs
+++ b/src/Bw.Cqrs/Commands/Base/InternalCommand.cs
@@ -1,5 +1,6 @@
 using Bw.Cqrs.Commands.Contracts;
 using Bw.Cqrs.Commands.Enums;
+using Newtonsoft.Json;
 
 namespace Bw.Cqrs.Commands.Base;
 
@@ -27,17 +28,41 @@ public abstract class InternalCommand : CommandBase, IInternalCommand
     public InternalCommandStatus Status { get; private set; }
 
     /// <summary>
-    /// Initializes a new instance of the InternalCommand class
+    /// Internal command constructor.
     /// </summary>
-    /// <param name="executeAt">The date and time to execute the command</param> 
-    protected InternalCommand(DateTime? executeAt = null)
+    protected InternalCommand() : base()
     {
         ScheduledOn = DateTime.UtcNow;
-        ExecuteAt = executeAt ?? ScheduledOn;
+        ExecuteAt = ScheduledOn;
         Status = InternalCommandStatus.Scheduled;
         RetryCount = 0;
+    }
 
-        if (ExecuteAt < ScheduledOn)
+    /// <summary>
+    /// Internal command constructor.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="timestamp"></param>
+    /// <param name="scheduledOn"></param>
+    /// <param name="executeAt"></param>
+    /// <param name="processedOn"></param>
+    /// <param name="retryCount"></param>
+    /// <param name="error"></param>
+    /// <param name="status"></param>
+    [JsonConstructor]
+    protected InternalCommand(Guid id, DateTime timestamp,
+                              DateTime scheduledOn, DateTime executeAt,
+                              DateTime? processedOn, int retryCount,
+                              string? error, InternalCommandStatus status)
+        : base(id, timestamp)
+    {
+        ScheduledOn = scheduledOn;
+        ExecuteAt = executeAt;
+        ProcessedOn = processedOn;
+        RetryCount = retryCount;
+        Error = error;
+        Status = status;
+               if (ExecuteAt < ScheduledOn)
         {
             throw new ArgumentException("Execute time cannot be in the past", nameof(executeAt));
         }
@@ -81,13 +106,13 @@ public abstract class InternalCommand : CommandBase, IInternalCommand
     /// <summary>
     /// Determines if the command can be retried
     /// </summary>
-    public bool CanRetry(int maxRetries) => 
+    public bool CanRetry(int maxRetries) =>
         Status == InternalCommandStatus.Failed && RetryCount < maxRetries;
 
     /// <summary>
     /// Determines if the command is ready to be executed
     /// </summary>
-    public bool IsReadyToExecute() => 
-        Status == InternalCommandStatus.Scheduled && 
+    public bool IsReadyToExecute() =>
+        Status == InternalCommandStatus.Scheduled &&
         ExecuteAt <= DateTime.UtcNow;
-} 
+}

--- a/src/Bw.Cqrs/Commands/Contracts/ICommandProcessor.cs
+++ b/src/Bw.Cqrs/Commands/Contracts/ICommandProcessor.cs
@@ -1,11 +1,12 @@
-﻿using Bw.Cqrs.Common.Results;
+﻿using Bw.Cqrs.Commands.Base;
+using Bw.Cqrs.Common.Results;
 
 namespace Bw.Cqrs.Commands.Contracts;
 
 /// <summary>
 /// Represents a command bus for dispatching commands
 /// </summary>
-public interface ICommandBus
+public interface ICommandProcessor
 {
     /// <summary>
     /// Dispatches a command asynchronously
@@ -37,5 +38,5 @@ public interface ICommandBus
     /// <typeparam name="TCommand">Type of the command</typeparam>
     /// <param name="command">Command to schedule</param>
     Task ScheduleAsync<TCommand>(TCommand command) 
-        where TCommand : IInternalCommand;
+        where TCommand : InternalCommand;
 }

--- a/src/Bw.Cqrs/Commands/Contracts/IInternalCommandStore.cs
+++ b/src/Bw.Cqrs/Commands/Contracts/IInternalCommandStore.cs
@@ -1,3 +1,4 @@
+using Bw.Cqrs.Commands.Base;
 using Bw.Cqrs.Commands.Enums;
 using Bw.Cqrs.Commands.Models;
 
@@ -11,12 +12,12 @@ public interface IInternalCommandStore
     /// <summary>
     /// Saves a command to the store
     /// </summary>
-    Task SaveAsync(IInternalCommand command, CancellationToken cancellationToken = default);
+    Task SaveAsync(InternalCommand command, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all commands that are ready to be executed
     /// </summary>
-    Task<IEnumerable<IInternalCommand>> GetCommandsToExecuteAsync(CancellationToken cancellationToken = default);
+    Task<IEnumerable<InternalCommand>> GetCommandsToExecuteAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the status of a command

--- a/src/Bw.Cqrs/Commands/Services/InMemoryInternalCommandStore.cs
+++ b/src/Bw.Cqrs/Commands/Services/InMemoryInternalCommandStore.cs
@@ -12,7 +12,7 @@ namespace Bw.Cqrs.Commands.Services;
 /// </summary>
 public class InMemoryInternalCommandStore : IInternalCommandStore
 {
-    private readonly ConcurrentDictionary<Guid, IInternalCommand> _commands = new();
+    private readonly ConcurrentDictionary<Guid, InternalCommand> _commands = new();
     private readonly ILogger<InMemoryInternalCommandStore> _logger;
 
     /// <summary>
@@ -30,15 +30,15 @@ public class InMemoryInternalCommandStore : IInternalCommandStore
     /// <param name="command">The command</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>A task</returns>
-    public Task SaveAsync(IInternalCommand command, CancellationToken cancellationToken = default)
+    public Task SaveAsync(InternalCommand command, CancellationToken cancellationToken = default)
     {
-        if (_commands.TryAdd(((CommandBase)command).Id, command))
+        if (_commands.TryAdd(command.Id, command))
         {
-            _logger.LogDebug("Command {CommandId} saved successfully", ((CommandBase)command).Id);
+            _logger.LogDebug("Command {CommandId} saved successfully", command.Id);
             return Task.CompletedTask;
         }
 
-        throw new InvalidOperationException($"Command with ID {((CommandBase)command).Id} already exists");
+        throw new InvalidOperationException($"Command with ID {command.Id} already exists");
     }
 
     /// <summary>
@@ -46,14 +46,14 @@ public class InMemoryInternalCommandStore : IInternalCommandStore
     /// </summary>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>A task</returns>
-    public Task<IEnumerable<IInternalCommand>> GetCommandsToExecuteAsync(CancellationToken cancellationToken = default)
+    public Task<IEnumerable<InternalCommand>> GetCommandsToExecuteAsync(CancellationToken cancellationToken = default)
     {
         var commands = _commands.Values
             .Where(x => x is InternalCommand ic && ic.IsReadyToExecute())
             .ToList();
 
         _logger.LogDebug("Found {Count} commands ready to execute", commands.Count);
-        return Task.FromResult<IEnumerable<IInternalCommand>>(commands);
+        return Task.FromResult<IEnumerable<InternalCommand>>(commands);
     }
 
     /// <summary>

--- a/src/Bw.Cqrs/Events/Contracts/IEventProcessor.cs
+++ b/src/Bw.Cqrs/Events/Contracts/IEventProcessor.cs
@@ -3,7 +3,7 @@ namespace Bw.Cqrs.Events.Contracts;
 /// <summary>
 /// Represents the event bus for publishing events to registered handlers
 /// </summary>
-public interface IEventBus
+public interface IEventProcessor
 {
     /// <summary>
     /// Publishes the specified event to all registered handlers

--- a/src/Bw.Cqrs/Events/Services/InMemoryEventBus.cs
+++ b/src/Bw.Cqrs/Events/Services/InMemoryEventBus.cs
@@ -7,7 +7,7 @@ namespace Bw.Cqrs.Events.Services;
 /// <summary>
 /// In-memory implementation of the event bus that dispatches events to registered handlers
 /// </summary>
-public class InMemoryEventBus : IEventBus
+public class InMemoryEventBus : IEventProcessor
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<InMemoryEventBus> _logger;
@@ -63,7 +63,7 @@ public class InMemoryEventBus : IEventBus
         foreach (var @event in events)
         {
             // Use reflection to call the generic PublishAsync method
-            var method = typeof(IEventBus)
+            var method = typeof(IEventProcessor)
                 .GetMethod(nameof(PublishAsync), new[] { @event.GetType(), typeof(CancellationToken) });
 
             if (method == null)

--- a/src/Bw.Cqrs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Bw.Cqrs/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,8 @@ using Bw.Cqrs.Commands.Configuration;
 using Bw.Cqrs.Commands.Contracts;
 using Microsoft.Extensions.Options;
 using System.Data;
+using Bw.Cqrs.Queries.Contracts;
+using Bw.Cqrs.Queries.Services;
 
 namespace Bw.Cqrs.Extensions;
 
@@ -29,8 +31,10 @@ public static class ServiceCollectionExtensions
     public static ICqrsBuilder AddBwCqrs(this IServiceCollection services, Action<ICqrsBuilder> configure, params Assembly[] assemblies)
     {
         // Register core services
-        services.AddScoped<ICommandBus, DefaultCommandBus>();
+        services.AddScoped<ICommandProcessor, CommandProccesor>();
+        services.AddScoped<IQueryProcessor, QueryProcessor>();
         services.AddScoped<ICommandHandlerFactory, CommandHandlerFactory>();
+        services.AddScoped<IQueryHandlerFactory, QueryHandlerFactory>();
         services.AddScoped<IInternalCommandStore, InMemoryInternalCommandStore>();
 
         // Register command handlers
@@ -133,7 +137,7 @@ public static class ServiceCollectionExtensions
     /// <returns>The CQRS builder for method chaining</returns>
     public static ICqrsBuilder AddEventHandling(this ICqrsBuilder builder)
     {
-        builder.Services.AddScoped<IEventBus, InMemoryEventBus>();
+        builder.Services.AddScoped<IEventProcessor, InMemoryEventBus>();
 
         // Register event handlers
         builder.Services.Scan(scan => scan

--- a/src/Bw.Cqrs/Queries/Contracts/IQueryProcessor.cs
+++ b/src/Bw.Cqrs/Queries/Contracts/IQueryProcessor.cs
@@ -3,7 +3,7 @@ namespace Bw.Cqrs.Queries.Contracts;
 /// <summary>
 /// Represents a query bus that can send queries and receive responses
 /// </summary>
-public interface IQueryBus
+public interface IQueryProcessor
 {
     /// <summary>
     /// Sends a query to the query bus and returns a response

--- a/src/Bw.Cqrs/Queries/Services/QueryProcessor.cs
+++ b/src/Bw.Cqrs/Queries/Services/QueryProcessor.cs
@@ -6,7 +6,7 @@ namespace Bw.Cqrs.Queries.Services;
 /// <summary>
 /// Default implementation of IQueryBus
 /// </summary>
-public class DefaultQueryBus : IQueryBus
+public class QueryProcessor : IQueryProcessor
 {
     private readonly IServiceProvider _serviceProvider;
 
@@ -14,7 +14,7 @@ public class DefaultQueryBus : IQueryBus
     /// Initializes a new instance of the DefaultQueryBus class
     /// </summary>
     /// <param name="serviceProvider">The service provider</param>
-    public DefaultQueryBus(IServiceProvider serviceProvider)
+    public QueryProcessor(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
     }

--- a/src/samples/OrderManagement/src/OrderManagement.API/Controllers/OrdersController.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.API/Controllers/OrdersController.cs
@@ -1,32 +1,23 @@
-using System;
-using System.Threading.Tasks;
-
-using Bw.Cqrs.Commands;
 using Bw.Cqrs.Commands.Contracts;
-
+using Bw.Cqrs.Queries.Contracts;
 using Microsoft.AspNetCore.Mvc;
-
 using OrderManagement.Application.Orders.Commands.CreateOrder;
 using OrderManagement.Application.Orders.Commands.UpdateOrderStatus;
+using OrderManagement.Application.Orders.Queries.GetOrders;
 
 namespace OrderManagement.API.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class OrdersController : ControllerBase
+public class OrdersController(ICommandProcessor commandProcessor,IQueryProcessor queryProcessor) : ControllerBase
 {
-    private readonly ICommandBus _commandBus;
 
-    public OrdersController(ICommandBus commandBus)
-    {
-        _commandBus = commandBus;
-    }
-
+    
     [HttpPost]
     public async Task<IActionResult> CreateOrder([FromBody] CreateOrderRequest request)
     {
         var command = new CreateOrderCommand(request);
-        await _commandBus.DispatchAsync(command);
+        await commandProcessor.DispatchAsync(command);
         return Ok();
     }
 
@@ -36,7 +27,16 @@ public class OrdersController : ControllerBase
         [FromBody] UpdateOrderStatusRequest request)
     {
         var command = new UpdateOrderStatusCommand(id, request);
-        await _commandBus.DispatchAsync(command);
+        await commandProcessor.DispatchAsync(command);
         return Ok();
+    }
+
+
+    [HttpGet]
+    public async Task<IActionResult> GetOrders()
+    {
+        var query = new GetOrderQuery();
+        var result = await queryProcessor.SendAsync(query);
+        return Ok(result);
     }
 } 

--- a/src/samples/OrderManagement/src/OrderManagement.API/OrderManagement.API.csproj
+++ b/src/samples/OrderManagement/src/OrderManagement.API/OrderManagement.API.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.1.24081.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">

--- a/src/samples/OrderManagement/src/OrderManagement.API/Program.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.API/Program.cs
@@ -10,8 +10,8 @@ using OrderManagement.Infrastructure.Repositories;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddControllers();
-builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddControllers()
+    .AddNewtonsoftJson();builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "Order Management API", Version = "v1" });
@@ -41,7 +41,7 @@ builder.Services.AddBwCqrs(builder =>
         {
             options.MaxRetries = 3;
             options.RetryDelaySeconds = 60;
-            options.ProcessingIntervalSeconds = 10;
+            options.ProcessingIntervalSeconds = 30;
             options.RetentionDays = 7;
         })
         .UsePostgres(options =>

--- a/src/samples/OrderManagement/src/OrderManagement.API/Properties/launchSettings.json
+++ b/src/samples/OrderManagement/src/OrderManagement.API/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "applicationUrl": "http://localhost:5148",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/samples/OrderManagement/src/OrderManagement.Application/Orders/Commands/CreateOrder/CreateOrderCommandHandler.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Application/Orders/Commands/CreateOrder/CreateOrderCommandHandler.cs
@@ -11,14 +11,14 @@ namespace OrderManagement.Application.Orders.Commands.CreateOrder;
 public class CreateOrderCommandHandler : ICommandHandler<CreateOrderCommand>
 {
     private readonly IOrderRepository _orderRepository;
-    private readonly IEventBus _eventBus;
+    private readonly IEventProcessor _eventProcessor;
 
     public CreateOrderCommandHandler(
         IOrderRepository orderRepository,
-        IEventBus eventBus)
+        IEventProcessor eventBus)
     {
         _orderRepository = orderRepository;
-        _eventBus = eventBus;
+        _eventProcessor = eventBus;
     }
 
     public async Task<IResult> HandleAsync(CreateOrderCommand command, CancellationToken cancellationToken = default)
@@ -37,7 +37,7 @@ public class CreateOrderCommandHandler : ICommandHandler<CreateOrderCommand>
             order.Id, 
             order.OrderNumber, 
             order.CreatedAt);
-        await _eventBus.PublishAsync(@event);
+        await _eventProcessor.PublishAsync(@event);
 
         return CommandResult.Success();
     }

--- a/src/samples/OrderManagement/src/OrderManagement.Application/Orders/EventHandlers/OrderCreatedEventHandler.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Application/Orders/EventHandlers/OrderCreatedEventHandler.cs
@@ -11,16 +11,16 @@ namespace OrderManagement.Application.Orders.EventHandlers;
 
 public class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
 {
-    private readonly ICommandBus _commandBus;
+    private readonly ICommandProcessor _commandProcessor;
     private readonly IOrderRepository _orderRepository;
     private readonly ILogger<OrderCreatedEventHandler> _logger;
 
     public OrderCreatedEventHandler(
-        ICommandBus commandBus,
+        ICommandProcessor commandBus,
         IOrderRepository orderRepository,
         ILogger<OrderCreatedEventHandler> logger)
     {
-        _commandBus = commandBus;
+        _commandProcessor = commandBus;
         _orderRepository = orderRepository;
         _logger = logger;
     }
@@ -43,7 +43,7 @@ public class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
             // In a real application, you would get the customer email from the order
             CustomerEmail = "customer@example.com"
         };
-        await _commandBus.ScheduleAsync(command);
+        await _commandProcessor.ScheduleAsync(command);
 
         _logger.LogInformation(
             "Order {OrderNumber} created and confirmation email scheduled",

--- a/src/samples/OrderManagement/src/OrderManagement.Application/Orders/InternalCommands/SendOrderConfirmationEmailCommand.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Application/Orders/InternalCommands/SendOrderConfirmationEmailCommand.cs
@@ -1,12 +1,24 @@
-using Bw.Cqrs.Commands;
+using Bw.Cqrs.Command;
+using Bw.Cqrs.Command.Contract;
 using Bw.Cqrs.Commands.Base;
+using Bw.Cqrs.Commands.Enums;
+using Bw.Cqrs.Common.Results;
 
 namespace OrderManagement.Application.Orders.InternalCommands;
 
 public class SendOrderConfirmationEmailCommand : InternalCommand
 {
+
     public Guid OrderId { get; set; }
     public string CustomerEmail { get; set; } = string.Empty;
     public string OrderNumber { get; set; } = string.Empty;
     public decimal TotalAmount { get; set; }
-} 
+}
+
+public class SendOrderConfirmationEmailCommandHandler : ICommandHandler<SendOrderConfirmationEmailCommand>
+{
+    public Task<IResult> HandleAsync(SendOrderConfirmationEmailCommand command, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult((IResult)new CommandResult(true,"Email sent successfully"));    
+    }
+}

--- a/src/samples/OrderManagement/src/OrderManagement.Application/Orders/Queries/GetOrders/GetOrderQuery.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Application/Orders/Queries/GetOrders/GetOrderQuery.cs
@@ -1,0 +1,18 @@
+using Bw.Cqrs.Queries.Contracts;
+using OrderManagement.Domain.Models;
+
+namespace OrderManagement.Application.Orders.Queries.GetOrders;
+
+
+
+public class OrdersResponse
+{
+    public Guid Id { get; set; }
+    public string OrderNumber { get; set; } = default!;
+    public OrderStatus Status { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+public record GetOrderQuery : IQuery<IEnumerable<OrdersResponse>>
+{
+}

--- a/src/samples/OrderManagement/src/OrderManagement.Application/Orders/Queries/GetOrders/GetOrderQueryHandler.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Application/Orders/Queries/GetOrders/GetOrderQueryHandler.cs
@@ -1,0 +1,26 @@
+using Bw.Cqrs.Queries.Contracts;
+using OrderManagement.Domain.Repositories;
+
+namespace OrderManagement.Application.Orders.Queries.GetOrders;
+
+public class GetOrderQueryHandler(IOrderRepository orderRepository) : IQueryHandler<GetOrderQuery, IEnumerable<OrdersResponse>>
+{
+    public async Task<IEnumerable<OrdersResponse>> HandleAsync(GetOrderQuery query)
+    {
+        var orders = await orderRepository.GetAllAsync();
+        var result = new List<OrdersResponse>();
+
+        foreach (var item in orders)
+        {
+            result.Add(new OrdersResponse
+            {
+                Id = item.Id,
+                OrderNumber = item.OrderNumber,
+                Status = item.Status,
+                CreatedAt = item.CreatedAt
+            });
+        }
+        return result;
+
+    }
+}

--- a/src/samples/OrderManagement/src/OrderManagement.Domain/Events/OrderCreatedEvent.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Domain/Events/OrderCreatedEvent.cs
@@ -3,7 +3,7 @@ using Bw.Cqrs.Events.Base;
 
 namespace OrderManagement.Domain.Events;
 
-public class OrderCreatedEvent :Event
+public class OrderCreatedEvent : Event
 {
     public Guid OrderId { get; }
     public string OrderNumber { get; }
@@ -15,4 +15,4 @@ public class OrderCreatedEvent :Event
         OrderNumber = orderNumber;
         CreatedAt = createdAt;
     }
-} 
+}

--- a/src/samples/OrderManagement/src/OrderManagement.Domain/Repositories/IOrderRepository.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Domain/Repositories/IOrderRepository.cs
@@ -9,4 +9,5 @@ public interface IOrderRepository
     Task<Order?> GetByIdAsync(Guid id);
     Task AddAsync(Order order);
     Task UpdateAsync(Order order);
+    Task<IEnumerable<Order>> GetAllAsync();
 } 

--- a/src/samples/OrderManagement/src/OrderManagement.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/samples/OrderManagement/src/OrderManagement.Infrastructure/Repositories/OrderRepository.cs
@@ -32,4 +32,9 @@ public class OrderRepository : IOrderRepository
         _context.Orders.Update(order);
         await _context.SaveChangesAsync();
     }
+
+    public async Task<IEnumerable<Order>> GetAllAsync()
+    {
+        return await _context.Orders.AsNoTracking().ToListAsync();
+    }
 } 

--- a/tests/Bw.Cqrs.Tests/Commands/Services/DefaultCommandBusTests.cs
+++ b/tests/Bw.Cqrs.Tests/Commands/Services/DefaultCommandBusTests.cs
@@ -16,14 +16,14 @@ public class DefaultCommandBusTests
     private readonly Mock<ICommandHandlerFactory> _handlerFactoryMock;
     private readonly Mock<IServiceProvider> _serviceProviderMock;
     private readonly Mock<IInternalCommandStore> _commandStoreMock;
-    private readonly DefaultCommandBus _commandBus;
+    private readonly CommandProccesor _commandBus;
 
     public DefaultCommandBusTests()
     {
         _handlerFactoryMock = new Mock<ICommandHandlerFactory>();
         _serviceProviderMock = new Mock<IServiceProvider>();
         _commandStoreMock = new Mock<IInternalCommandStore>();
-        _commandBus = new DefaultCommandBus(_handlerFactoryMock.Object, _commandStoreMock.Object, _serviceProviderMock.Object);
+        _commandBus = new CommandProccesor(_handlerFactoryMock.Object, _commandStoreMock.Object, _serviceProviderMock.Object);
     }
 
 

--- a/tests/Bw.Cqrs.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/Bw.Cqrs.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -24,8 +24,8 @@ public class ServiceCollectionExtensionsTests
         var serviceProvider = services.BuildServiceProvider();
 
         // Assert
-        serviceProvider.GetService<IEventBus>().Should().NotBeNull();
-        serviceProvider.GetService<IEventBus>().Should().BeOfType<InMemoryEventBus>();
+        serviceProvider.GetService<IEventProcessor>().Should().NotBeNull();
+        serviceProvider.GetService<IEventProcessor>().Should().BeOfType<InMemoryEventBus>();
     }
 
     [Fact]


### PR DESCRIPTION

**Renamed Interfaces** for better clarity and naming convention:
  - `ICommandBus` → `ICommandProcessor`
  - `IEventBus` → `IEventProcessor`
  - `IQueryBus` → `IQueryProcessor`

**InternalCommand Improvements**:
  - Fixed handler resolution for `InternalCommand` types
  - Tracked and updated execution status in DB properly

**Serialization Fix**:
  - Replaced `System.Text.Json` with `Newtonsoft.Json` to support parameterized constructors during deserialization

**Dependency Injection Fixes**:
  - Proper DI support for `IQuery` and `IQueryHandler`

**Sample Updated**:
  - Changes are also applied to the [`OrderManagement` sample project]
